### PR TITLE
CA-121668: Move plugins to init level 23

### DIFF
--- a/init.d-rrdd-plugins
+++ b/init.d-rrdd-plugins
@@ -2,7 +2,7 @@
 #
 # xcp-rrdd-plugins     Start/Stop the XCP RRD daemon plugins
 #
-# chkconfig: 2345 18 82
+# chkconfig: 2345 23 82
 # description: XCP RRD daemon plugins
 
 # Source function library.


### PR DESCRIPTION
As part of EA-1254 xcp-rrdd moved to init level 22; ever since then the plugins have been trying (and failing) to start up before xcp-rrdd.
