### PR TITLE
CP-8639: Enable core dumps

### DIFF
--- a/init.d-rrdd-plugins
+++ b/init.d-rrdd-plugins
@@ -27,6 +27,9 @@ PID_PREFIX="/var/run/"
 # lock file
 SUBSYS_PREFIX="/var/lock/subsys/"
 
+# Enable core dumping
+ulimit -c unlimited
+
 start() {
 	WORST_RETVAL=0
 	for NAME in ${PLUGINS}; do


### PR DESCRIPTION
Call ulimit -c unlimited the xcp-rrdd-plugins script, so core files can be written.

See also https://github.com/xapi-project/xen-api/pull/1777

Signed-off-by: Euan Harris euan.harris@citrix.com
