### PR TITLE
CA-138835: rrdd plugins should exit on sigterm/sigint

### DIFF
--- a/rrdp_common.ml
+++ b/rrdp_common.ml
@@ -149,7 +149,8 @@ let list_directory_entries_unsafe dir =
 
 let unregister signum =
 	info "Received signal %d: deregistering plugin %s..." signum N.name;
-	RRDD.Plugin.deregister N.name
+	RRDD.Plugin.deregister N.name;
+	exit 0
 
 (* Plugins should call initialise () before spawning any threads. *)
 let initialise () =


### PR DESCRIPTION
Otherwise the main loop catches the signal and continues running, and
the init script eventually has to send SIGKILL.
