### PR TITLE
Remove references to common Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-include $(B_BASE)/common.mk
-include $(B_BASE)/rpmbuild.mk
-
 TARGETS = rrdp_iostat \
 	 rrdp_squeezed \
 	 rrdp_xenpm


### PR DESCRIPTION
These files aren't used, and don't exist in mock-land.
