### PR TITLE
CA-142270: Include blktap3 perf data to host level stats

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -42,11 +42,16 @@ export
 
 OCAMLPACKS = str xenctrl xenstore-watch rrdd-plugin
 
+OCAML_CLIBS = blktap3_stats_stubs
+StaticCLibrary(blktap3_stats_stubs, blktap3_stats_stubs)
+CFLAGS+=-I$(shell ocamlc -where)
+
 RRDP_DUMMY = rrdp_dummy
 RRDP_DUMMY_FILES = \
 	rrdp_dummy
 RRDP_IOSTAT = rrdp_iostat
 RRDP_IOSTAT_FILES = \
+	blktap3_stats \
 	rrdp_iostat
 RRDP_XENPM = rrdp_xenpm
 RRDP_XENPM_FILES = \

--- a/blktap3_stats.ml
+++ b/blktap3_stats.ml
@@ -1,0 +1,39 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(*
+ * This module extracts the external declaration to make things easier
+ * for a library which might be used elsewhere.
+*)
+
+(** Define an equivalent blktap3 statistics record *)
+type blktap3_stats = {
+	st_ds_req : int64;
+	st_f_req  : int64;
+	st_oo_req : int64;
+	st_rd_req : int64;
+	st_rd_cnt : int64;
+	st_rd_sect: int64;
+	st_rd_sum_usecs : int64;
+	st_rd_max_usecs : int64;
+	st_wr_req : int64;
+	st_wr_cnt : int64;
+	st_wr_sect: int64;
+	st_wr_sum_usecs : int64;
+	st_wr_max_usecs : int64;
+}
+
+(** Obtain a blktap3 statistics record using the stubs *)
+external get_blktap3_stats:
+	filename:string -> blktap3_stats = "stub_get_blktap3_stats"

--- a/blktap3_stats.mli
+++ b/blktap3_stats.mli
@@ -1,0 +1,51 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+(**
+ * This module defines an equivalent blktap3 stats record and the
+ * associated API method.
+ *)
+
+(** Attributes associated with the blktap3 stats struct *)
+type blktap3_stats = {
+	(** BLKIF_OP_DISCARD, not currently supported in blktap3, zero always *)
+	st_ds_req : int64;
+	(** BLKIF_OP_FLUSH_DISKCACHE, not currently supported in blktap3, zero always*)
+	st_f_req  : int64;
+	(** Increased each time we fail to allocate memory for a internal
+	 * request descriptor in response to a ring request. *)
+	st_oo_req : int64;
+	(** Received BLKIF_OP_READ requests. *)
+	st_rd_req : int64;
+	(** Completed BLKIF_OP_READ requests. *)
+	st_rd_cnt : int64;
+	(** Read sectors, after we've forwarded the request to actual storage. *)
+	st_rd_sect: int64;
+	(** Sum of the request response time of all BLKIF_OP_READ *)
+	st_rd_sum_usecs : int64;
+	(** Absolute maximum BLKIF_OP_READ response time *)
+	st_rd_max_usecs : int64;
+	(** Received BLKIF_OP_WRITE requests. *)
+	st_wr_req : int64;
+	(** Completed BLKIF_OP_WRITE requests. *)
+	st_wr_cnt : int64;
+	(** Write sectors, after we've forwarded the request to actual storage. *)
+	st_wr_sect: int64;
+	(** Sum of the request response time of all BLKIF_OP_WRITE *)
+	st_wr_sum_usecs : int64;
+	(** Absolute maximum BLKIF_OP_WRITE response time *)
+	st_wr_max_usecs : int64;
+}
+
+(** Get a blktap3 statistics record *)
+val get_blktap3_stats: filename:string -> blktap3_stats

--- a/blktap3_stats_stubs.c
+++ b/blktap3_stats_stubs.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2006-2009 Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ */
+
+/*
+  This stubs file retrieves the blkback statistics struct created by
+  blktap3 under '/dev/shm/<vbd3-domid-devid>/statistics' *)
+*/
+
+#include <stdio.h>
+#include <errno.h>
+#include <blktap/blktap3.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/unixsupport.h>
+
+
+CAMLprim value stub_get_blktap3_stats(value filename)
+{
+
+	CAMLparam1(filename);
+	CAMLlocal1(stats);
+
+	FILE *c_fd;
+	struct blkback_stats c_stats;
+
+	c_fd = fopen(String_val(filename), "rb");
+
+	if (!c_fd) uerror("fopen", Nothing);
+	if (fread(&c_stats, sizeof(struct blkback_stats), 1, c_fd) < 1) uerror("fread", Nothing);
+
+	stats = caml_alloc_tuple(13);
+
+	Store_field(stats, 0, caml_copy_int64((int64) c_stats.st_ds_req));
+	Store_field(stats, 1, caml_copy_int64((int64) c_stats.st_f_req));
+	Store_field(stats, 2, caml_copy_int64((int64) c_stats.st_oo_req));
+	Store_field(stats, 3, caml_copy_int64((int64) c_stats.st_rd_req));
+	Store_field(stats, 4, caml_copy_int64((int64) c_stats.st_rd_cnt));
+	Store_field(stats, 5, caml_copy_int64((int64) c_stats.st_rd_sect));
+	Store_field(stats, 6, caml_copy_int64((int64) c_stats.st_rd_sum_usecs));
+	Store_field(stats, 7, caml_copy_int64((int64) c_stats.st_rd_max_usecs));
+	Store_field(stats, 8, caml_copy_int64((int64) c_stats.st_wr_req));
+	Store_field(stats, 9, caml_copy_int64((int64) c_stats.st_wr_cnt));
+	Store_field(stats, 10, caml_copy_int64((int64) c_stats.st_wr_sect));
+	Store_field(stats, 11, caml_copy_int64((int64) c_stats.st_wr_sum_usecs));
+	Store_field(stats, 12, caml_copy_int64((int64) c_stats.st_wr_max_usecs));
+
+	fclose(c_fd);
+
+	CAMLreturn(stats);
+
+}


### PR DESCRIPTION
Host level metrics were accumulated from the VDI level stats. Prior XS
6.5, the VDI level stats were read from sysfs. With blktap3, stats
exposed under /dev/shm should also be taken into account.

Signed-off-by: Kaifeng Zhu kaifeng.zhu@citrix.com
