### PR TITLE
CP-9798: Update init script for systemd compatibility (for review only)

### DIFF
--- a/init.d-rrdd-plugins
+++ b/init.d-rrdd-plugins
@@ -21,7 +21,6 @@ fi
 #CMD_PREFIX="@LIBEXECDIR@/${NAME}/"
 CMD_PREFIX="/opt/xensource/libexec/${NAME}/"
 
-# pidfile:
 PID_PREFIX="/var/run/"
 
 # lock file


### PR DESCRIPTION
systemd parses magic lines in sysv init scripts (like sysv init does).
However, the pidfile line causes hangs on startup, so remove it.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>