### PR TITLE
Silence cache warning for dom0.

### DIFF
--- a/rrdp_squeezed.ml
+++ b/rrdp_squeezed.ml
@@ -94,7 +94,8 @@ let get_squeezed_data domid =
 	let get_current_value ~label current_values =
 		try IntMap.find domid !current_values
 		with _ ->
-			D.warn "Couldn't find cached %s value for domain %d, using 0" label domid;
+			if domid != 0
+			then D.warn "Couldn't find cached %s value for domain %d, using 0" label domid;
 			0L
 	in
 	(


### PR DESCRIPTION
At the moment the log file is accumulating a line every five seconds,
I can't see this message is useful.

Signed-off-by: Simon Rowe <simonr@eu.citrix.com>