### PR TITLE
CP-12967: Change xcp-rrdd-iostat to produce a new RRD for number of tapdisks in low memory mode

### DIFF
--- a/blktap3_stats.ml
+++ b/blktap3_stats.ml
@@ -32,6 +32,7 @@ type blktap3_stats = {
 	st_wr_sect: int64;
 	st_wr_sum_usecs : int64;
 	st_wr_max_usecs : int64;
+	st_mem_mode : bool;
 }
 
 (** Obtain a blktap3 statistics record using the stubs *)

--- a/blktap3_stats.mli
+++ b/blktap3_stats.mli
@@ -45,6 +45,8 @@ type blktap3_stats = {
 	st_wr_sum_usecs : int64;
 	(** Absolute maximum BLKIF_OP_WRITE response time *)
 	st_wr_max_usecs : int64;
+	(** Tapdisk Low memory mode *)
+	st_mem_mode : bool;
 }
 
 (** Get a blktap3 statistics record *)

--- a/blktap3_stats_stubs.c
+++ b/blktap3_stats_stubs.c
@@ -43,7 +43,7 @@ CAMLprim value stub_get_blktap3_stats(value filename)
 	if (!c_fd) uerror("fopen", Nothing);
 	if (fread(&c_stats, sizeof(struct blkback_stats), 1, c_fd) < 1) uerror("fread", Nothing);
 
-	stats = caml_alloc_tuple(13);
+	stats = caml_alloc_tuple(14);
 
 	Store_field(stats, 0, caml_copy_int64((int64) c_stats.st_ds_req));
 	Store_field(stats, 1, caml_copy_int64((int64) c_stats.st_f_req));
@@ -58,6 +58,10 @@ CAMLprim value stub_get_blktap3_stats(value filename)
 	Store_field(stats, 10, caml_copy_int64((int64) c_stats.st_wr_sect));
 	Store_field(stats, 11, caml_copy_int64((int64) c_stats.st_wr_sum_usecs));
 	Store_field(stats, 12, caml_copy_int64((int64) c_stats.st_wr_max_usecs));
+	if ((c_stats.flags) & BT3_LOW_MEMORY_MODE)
+		Store_field(stats, 13, Val_true);
+	else
+		Store_field(stats, 13, Val_false);
 
 	fclose(c_fd);
 


### PR DESCRIPTION
Added new RRD for number of tapdisks in low memory mode

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>