### PR TITLE
CP-12750: add specific logrotate configuration

### DIFF
--- a/OMakefile
+++ b/OMakefile
@@ -71,6 +71,8 @@ install: $(RRDP_IOSTAT) $(RRDP_XENPM) $(RRDP_SQUEEZED)
 	install -m 755 init.d-rrdd-plugins $(DESTDIR)/etc/rc.d/init.d/xcp-rrdd-plugins
 	mkdir -p $(DESTDIR)/etc/sysconfig
 	install -m 755 sysconfig-rrdd-plugins $(DESTDIR)/etc/sysconfig/xcp-rrdd-plugins
+	mkdir -p $(DESTDIR)/etc/logrotate.d
+	install -m 644 logrotate-rrdd-plugins $(DESTDIR)/etc/logrotate.d/xcp-rrdd-plugins
 
 .PHONY: clean
 clean:

--- a/logrotate-rrdd-plugins
+++ b/logrotate-rrdd-plugins
@@ -1,0 +1,5 @@
+/var/log/xcp-rrdd-plugins.log {
+    postrotate
+        /bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+    endscript
+}


### PR DESCRIPTION
The monolithic logrotate-xenserver.conf is being split into separate
files to allow a more standard rotation policy with the new XenServer
partition layout.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>