### PR TITLE
CA-209087: Don't attempt to derive the VBD read/write stats

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -51,3 +51,11 @@ Executable rrdp_xenpm
                             str,
                             threads,
                             xenctrl
+
+Executable read_blktap_stats
+  CompiledObject:           best
+  Path:                     src
+  MainIs:                   read_blktap_stats.ml
+  Install:                  false
+  BuildDepends:             rrdd-plugins-libs,
+                            unix

--- a/src/read_blktap_stats.ml
+++ b/src/read_blktap_stats.ml
@@ -1,0 +1,35 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+let usage () =
+	Printf.printf "Usage:\n";
+	Printf.printf "%s <stats-file>\n" Sys.argv.(0);
+	exit 1
+
+let () =
+	match Sys.argv with
+	| [|_; filename|] -> begin
+		let stats = Blktap3_stats.get_blktap3_stats filename in
+		Printf.printf "read_reqs_submitted = %Ld\n" stats.Blktap3_stats.read_reqs_submitted;
+		Printf.printf "read_reqs_completed = %Ld\n" stats.Blktap3_stats.read_reqs_completed;
+		Printf.printf "read_sectors = %Ld\n" stats.Blktap3_stats.read_sectors;
+		Printf.printf "read_total_ticks = %Ld\n" stats.Blktap3_stats.read_total_ticks;
+		Printf.printf "write_reqs_submitted = %Ld\n" stats.Blktap3_stats.write_reqs_submitted;
+		Printf.printf "write_reqs_completed = %Ld\n" stats.Blktap3_stats.write_reqs_completed;
+		Printf.printf "write_sectors = %Ld\n" stats.Blktap3_stats.write_sectors;
+		Printf.printf "write_total_ticks = %Ld\n" stats.Blktap3_stats.write_total_ticks;
+		Printf.printf "io_errors = %Ld\n" stats.Blktap3_stats.io_errors;
+		Printf.printf "low_mem_mode = %b\n" stats.Blktap3_stats.low_mem_mode
+	end
+	| _ -> usage ()

--- a/src/rrdp_iostat.ml
+++ b/src/rrdp_iostat.ml
@@ -431,8 +431,8 @@ module Stats_value = struct
 				| Some last_s3 -> last_s3
 				in
 				{
-					rd_bytes = Int64.mul (Int64.sub s3.read_sectors last_s3.read_sectors) 512L;
-					wr_bytes = Int64.mul (Int64.sub s3.write_sectors last_s3.write_sectors) 512L;
+					rd_bytes = Int64.mul s3.read_sectors 512L;
+					wr_bytes = Int64.mul s3.write_sectors 512L;
 					rd_avg_usecs =
 						if s3.read_reqs_completed > 0L then
 							Int64.div s3.read_total_ticks s3.read_reqs_completed


### PR DESCRIPTION
These datasources are exported as the Derive type, which means rrdd will
handle the derivation for us.