### PR TITLE
Update _oasis

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -19,15 +19,15 @@ Executable rrdp_iostat
   Path:                     src
   MainIs:                   rrdp_iostat.ml
   Install:                  false
-  BuildDepends:             rrdd-plugin,
+  BuildDepends:             ezxenstore,
+                            rrdd-plugin,
                             rrdd-plugins-libs,
                             stdext,
                             str,
                             threads,
                             uuid,
                             xenctrl,
-                            xenstore.unix,
-                            xenstore-compat
+                            xenstore.unix
 
 Executable rrdp_squeezed
   CompiledObject:           best


### PR DESCRIPTION
This library was using the old `xenstore-compat` instead of the new `ezxenstore`.
It was still compiling because we forgot to release the new `xen-api-libs-transitional`. It will fail once we release the new one.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>