### PR TITLE
Reduce compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: c
-services: docker
-install:
-    - wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh
-script: bash travis-build-repo.sh
-sudo: true
+sudo: required
+service: docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
 env:
-    global:
-        - REPO_PACKAGE_NAME=rrdd-plugins
-        - REPO_CONFIGURE_CMD=true
-        - REPO_BUILD_CMD=make
-        - REPO_TEST_CMD=true
+  global:
+    - PACKAGE="rrdd-plugins"
+    - PINS="rrdd-plugins:."
+    - BASE_REMOTE="https://github.com/xapi-project/xs-opam.git"
+  matrix:
+    - DISTRO="debian-9-ocaml-4.07"

--- a/rrdd-plugins.opam
+++ b/rrdd-plugins.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 name: "rrdd-plugins"
 maintainer: "xs-devel@lists.xenserver.org"
 authors: [ "xs-devel@lists.xenserver.org" ]
@@ -7,21 +7,21 @@ homepage: "https://github.com/xenserver/rrdd-plugins"
 bug-reports: "https://github.com/xenserver/rrdd-plugins/issues"
 dev-repo: "git://github.com/xenserver/rrdd-plugins"
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
+synopsis: "Plugins registering to the RRD daemon and exposing various metrics"
 depends: [
+  "ocaml"
   "jbuilder" {build}
+  "base-threads"
+  "base-unix"
+  "cstruct-unix"
+  "ezxenstore"
   "inotify"
   "rrdd-plugin"
+  "uuid"
   "xapi-libs-transitional"
   "xapi-stdext-std"
   "xapi-stdext-unix"
-  "str"
-  "base-threads"
-  "ezxenstore"
-  "xenstore"
-  "xenops"
   "xenctrl"
-  "cstruct-unix"
-]
-depexts: [
-  [["centos"] ["blktap-devel"]]
+  "xenops"
+  "xenstore"
 ]

--- a/src/rrdp-squeezed/rrdp_squeezed.ml
+++ b/src/rrdp-squeezed/rrdp_squeezed.ml
@@ -13,7 +13,6 @@
  *)
 
 open Xapi_stdext_std
-open Xenstore
 open Rrdd_plugin
 
 module Process = Process(struct let name="xcp-rrdd-squeezed" end)
@@ -57,7 +56,7 @@ module MemoryActions = struct
 
   let watch_token domid = Printf.sprintf "xcp-rrdd-plugins/squeezed:domain-%d" domid
 
-  let watch_fired xc _ path domains watches =
+  let watch_fired _xc _ path domains _watches =
     D.debug "Watch fired on %s" path;
     let read_new_value domid current_memory_values =
       let domid = int_of_string domid in

--- a/src/rrdp-xenpm/rrdp_xenpm.ml
+++ b/src/rrdp-xenpm/rrdp_xenpm.ml
@@ -74,7 +74,7 @@ let get_states cpu_state : int64 list =
 (* list_package [1;2;3;4] 2 = [[1;2];[3;4]] *)
 let list_package (l:'a list) (n:int) : 'a list list =
   if n = 0 then failwith "Rrdp_xenpm.list_package: package too small";
-  let nbelt,accsmall,accbig =
+  let _nbelt,accsmall,accbig =
     List.fold_left (fun (nbelt, accsmall, accbig) elt ->
         if nbelt < n then (nbelt+1, elt::accsmall, accbig)
         else (1, [elt], (List.rev accsmall)::accbig)) (0,[],[]) l


### PR DESCRIPTION
Address warnings from "make build":

* unused variables
* redundant open statements

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>