### PR TITLE
XSI-400 Try to stop xcp-rrdd-isostat filling log

### DIFF
--- a/rrdd-plugins.opam
+++ b/rrdd-plugins.opam
@@ -24,4 +24,5 @@ depends: [
   "xenctrl"
   "xenops"
   "xenstore"
+  "mtime"
 ]

--- a/src/rrdp-iostat/dune
+++ b/src/rrdp-iostat/dune
@@ -13,5 +13,6 @@
     xenctrl
     xenstore.unix
     inotify
+    mtime.clock.os
   )
 )


### PR DESCRIPTION
Updating our mapping between VDIs and VMs appears
to spam the logs the most, so we try to reduce
occurences of this here.

We compare the latest VDIs (coming from the output
of `tap-ctl list`) to the VDIs in the previous
mapping to see if we actually do need to update
the map. We update the mapping regardless every
five minutes to avoid stale data.

Signed-off-by: lippirk <ben.anson@citrix.com>