### PR TITLE
CA-335964: Do not expose temporary VM UUIDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
-sudo: required
-service: docker
+services: docker
+os: linux
+dist: xenial
 install:
   - wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
   - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env


### PR DESCRIPTION
Now (vdi) iostats are exposed through the stable uuid VMs

This change is analogous to https://github.com/xapi-project/xcp-rrdd/pull/113