### PR TITLE
CA-339269 Average I/O latency in microseconds

### DIFF
--- a/src/rrdp-iostat/rrdp_iostat.ml
+++ b/src/rrdp-iostat/rrdp_iostat.ml
@@ -648,7 +648,7 @@ module Iostats_value = struct
       let opt f x = match x with | None -> 0L | Some x' -> f x' in
       let s3_usecs = (get_stats_read_total_ticks s3 ++ get_stats_write_total_ticks s3) -- (opt get_stats_read_total_ticks last_s3 ++ opt get_stats_write_total_ticks last_s3) in
       let s3_count = (get_stats_read_reqs_completed s3 ++ get_stats_write_reqs_completed s3) -- (opt get_stats_read_reqs_completed last_s3 ++ opt get_stats_write_reqs_completed last_s3) in
-      let s3_latency_average = if s3_count = 0L then 0. else to_float s3_usecs /. to_float s3_count /. 1000.0 in
+      let s3_latency_average = if s3_count = 0L then 0. else to_float s3_usecs /. to_float s3_count in
       (* refer to https://github.com/xenserver/xsiostat for the calculation below *)
       let avgqu_sz = to_float ((get_stats_read_total_ticks s3 ++ get_stats_write_total_ticks s3) -- (opt get_stats_read_total_ticks last_s3 ++ opt get_stats_write_total_ticks last_s3)) /. 1000_000.0 in
       {
@@ -670,7 +670,7 @@ module Iostats_value = struct
       owner, ds_make ~name:(key_format "latency")
         ~description:"Average I/O latency"
         ~value:(Rrd.VT_Float value.latency)
-        ~ty:Rrd.Gauge ~units:"milliseconds" ~min:0. ();
+        ~ty:Rrd.Gauge ~units:"μs" ~min:0. ();
       owner, ds_make ~name:(key_format "avgqu_sz")
         ~description:"Average I/O queue size"
         ~value:(Rrd.VT_Float value.avgqu_sz)


### PR DESCRIPTION
Rather than milliseconds, to match other latencies